### PR TITLE
fix: 调通 getNewStatusReport 方法

### DIFF
--- a/harmony/codePush/src/main/ets/CodePushUpdateManager.ts
+++ b/harmony/codePush/src/main/ets/CodePushUpdateManager.ts
@@ -273,6 +273,7 @@ export class CodePushUpdateManager {
     let info: object = this.getCurrentPackageInfo();
     let currentPackageFolderPath: string = this.getCurrentPackageFolderPath();
     FileUtils.deleteDirectoryAtPath(currentPackageFolderPath);
+    FileUtils.deleteDirectoryAtPath(this.getStatusFilePath());
     info[CodePushConstants.CURRENT_PACKAGE_KEY] = info[CodePushConstants.PREVIOUS_PACKAGE_KEY]
     info[CodePushConstants.PREVIOUS_PACKAGE_KEY] = null;
     this.updateCurrentPackageInfo(info);

--- a/src/NativeCodePush.ts
+++ b/src/NativeCodePush.ts
@@ -11,7 +11,7 @@ export interface Spec extends TurboModule {
   downloadUpdate(updatePackage: Object, notifyProgress: boolean): Promise<void>;
   getConfiguration(): Promise<object>;
   getUpdateMetadata(updateState: number): Promise<object>;
-  getNewStatusReport(): void;
+  getNewStatusReport(): Promise<object>;
   installUpdate(updatePackage: Object, installMode: number, minimumBackgroundDuration: number): Promise<object>;
   getLatestRollbackInfo(): Promise<string | null>;
   setLatestRollbackInfo(packageHash: string): Promise<string | null>;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- close #30 
- 调通 getNewStatusReport 方法
  - CodePush.ts新增initializeUpdateAfterRestart方法用于处理mDidUpdate值
  - Preferences调用flush方法进行持久化
  - 修复若干对象取值方式异常问题：由get取值改为普通对象键值对取值


## Test Plan

![image](https://github.com/user-attachments/assets/f48bdec5-f0f3-4b0a-8cb7-7fe4393e97d9)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

